### PR TITLE
💚 Run apt-get update before install

### DIFF
--- a/.github/workflows/test-jvm.yml
+++ b/.github/workflows/test-jvm.yml
@@ -19,7 +19,7 @@ jobs:
     steps:
       - name: Install OS dependencies
         if: ${{ inputs.dependencies != '' }}
-        run: sudo apt-get install ${{ inputs.dependencies }}
+        run: sudo apt-get update && sudo apt-get install ${{ inputs.dependencies }} --no-install-recommends  --no-install-suggests -y
 
       - name: Checkout repository
         uses: actions/checkout@v3


### PR DESCRIPTION
Sometimes tests that require specific dependencies fail for not finding dependencies in repos, adding an apt-get update fixes this.