### PR TITLE
🐛 HOCS-5439: Replace wget healthcheck with curl

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,7 +17,7 @@ services:
       HOCS_INFO_SERVICE: "http://info:8080"
       LOCALSTACK_HOST: "localstack"
     healthcheck:
-      test: "wget --no-verbose --tries=1 --spider http://localhost:8080/actuator/health || exit 1"
+      test: "curl --fail http://localhost:8080/actuator/health || exit 1"
       timeout: 5s
       retries: 40
     depends_on:
@@ -37,7 +37,7 @@ services:
       CAMUNDA_ADMIN_USERNAME: "admin"
       CAMUNDA_ADMIN_PASSWORD: "admin"
     healthcheck:
-      test: "wget --no-verbose --tries=1 --spider http://localhost:8080/actuator/health || exit 1"
+      test: "curl --fail http://localhost:8080/actuator/health || exit 1"
       timeout: 5s
       retries: 40
     depends_on:
@@ -69,7 +69,7 @@ services:
       JAVA_OPTS: "-Xms32m -Xmx128m"
       SERVER_PORT: 8080
     healthcheck:
-      test: "wget --no-verbose --tries=1 --spider http://localhost:8080/actuator/health || exit 1"
+      test: "curl --fail http://localhost:8080/actuator/health || exit 1"
       timeout: 5s
       retries: 40
 
@@ -105,7 +105,7 @@ services:
       DOCUMENT_S3_SECRET_KEY: "1234"
       DOCUMENT_S3_UNTRUSTED_BUCKET_NAME: "untrusted-bucket"
     healthcheck:
-      test: "wget --no-verbose --tries=1 --spider http://localhost:8080/actuator/health || exit 1"
+      test: "curl --fail http://localhost:8080/actuator/health || exit 1"
       timeout: 5s
       retries: 40
     depends_on:
@@ -135,7 +135,7 @@ services:
       HOCS_DOCUMENT_SERVICE: "http://documents:8080"
       AUDIT_TOPIC_NAME: "hocs-audit-topic"
     healthcheck:
-      test: "wget --no-verbose --tries=1 --spider http://localhost:8080/actuator/health || exit 1"
+      test: "curl --fail http://localhost:8080/actuator/health || exit 1"
       timeout: 5s
       retries: 40
     depends_on:
@@ -180,7 +180,7 @@ services:
       DB_HOST: "postgres"
       AWS_LOCAL_HOST: "localstack"
     healthcheck:
-      test: "wget --no-verbose --tries=1 --spider http://localhost:8080/actuator/health || exit 1"
+      test: "curl --fail http://localhost:8080/actuator/health || exit 1"
       timeout: 5s
       retries: 40
     depends_on:
@@ -208,7 +208,7 @@ services:
       S3_BUCKET: "untrusted-bucket"
       S3_ENDPOINT: http://localstack:4566
     healthcheck:
-      test: "wget --no-verbose --tries=1 --spider http://localhost:8080/health || exit 1"
+      test: "curl --fail http://localhost:8080/health || exit 1"
       timeout: 5s
       retries: 40
     depends_on:
@@ -244,7 +244,7 @@ services:
       AUDIT_QUEUE_DLQ_NAME: "audit-queue-dlq"
       HOCS_AUDIT_SERVICE: "http://audit:8080"
     healthcheck:
-      test: "wget --no-verbose --tries=1 --spider http://localhost:8080/actuator/health || exit 1"
+      test: "curl --fail http://localhost:8080/actuator/health || exit 1"
       timeout: 5s
       retries: 40
     depends_on:
@@ -319,7 +319,7 @@ services:
       ALLOWED_FILE_EXTENSIONS: "doc,docx,txt,rtf,html,pdf,jpg,jpeg,tif,tiff,png,bmp,gif,xls,xlsx,msg"
       PORT: 8080
     healthcheck:
-      test: "wget --no-verbose --tries=1 --spider http://localhost:8080/health || exit 1"
+      test: "curl --fail http://localhost:8080/health || exit 1"
       timeout: 5s
       retries: 40
     depends_on:
@@ -346,7 +346,7 @@ services:
       NOTIFY_QUEUE_DLQ_NAME: "notify-queue-dlq"
       NOTIFY_API_KEY: "aaaaaaaaaa-11111111-1111-1111-1111-111111111111-11111111-1111-1111-aaaa-aaaaaaaaaaaa"
     healthcheck:
-      test: "wget --no-verbose --tries=1 --spider http://localhost:8080/actuator/health || exit 1"
+      test: "curl --fail http://localhost:8080/actuator/health || exit 1"
       timeout: 5s
       retries: 40
     depends_on:
@@ -375,7 +375,7 @@ services:
 
   refresh_members:
     image: quay.io/ukhomeofficedigital/hocs-base-image:latest
-    command: ["wget", "-qo", "/dev/null", "http://info:8080/admin/member/refresh"]
+    command: ["curl", "http://info:8080/admin/member/refresh"]
     networks:
       - hocs-network
     depends_on:
@@ -406,7 +406,7 @@ services:
       HOCS_CASE_SERVICE: "http://casework:8080"
       HOCS_DOCUMENTS_SERVICE: "http://documents:8080"
     healthcheck:
-      test: "wget --no-verbose --tries=1 --spider http://localhost:8080/actuator/health || exit 1"
+      test: "curl --fail http://localhost:8080/actuator/health || exit 1"
       timeout: 5s
       retries: 40
     depends_on:
@@ -437,7 +437,7 @@ services:
       DB_SCHEMA_NAME: "workflow"
       AWS_LOCAL_HOST: "localstack"
     healthcheck:
-      test: "wget --no-verbose --tries=1 --spider http://localhost:8080/actuator/health || exit 1"
+      test: "curl --fail http://localhost:8080/actuator/health || exit 1"
       timeout: 5s
       retries: 40
     depends_on:


### PR DESCRIPTION
Ubuntu images don't contain wget, replace the healthchecks with a curl based one.