### PR TITLE
:bug: Increase helm timeout

### DIFF
--- a/helm/helm-deploy.sh
+++ b/helm/helm-deploy.sh
@@ -25,7 +25,7 @@ helm upgrade ${CHART_NAME} ./helm/${CHART_NAME} \
 --cleanup-on-fail \
 --install \
 --reset-values \
---timeout 3m \
+--timeout 10m \
 --history-max 3 \
 --namespace ${KUBE_NAMESPACE} \
 --set hocs-backend-service.version=${VERSION} \


### PR DESCRIPTION
In not-production environments the timeout isn't great enough for ACP to increase the available nodes for the services. This is causing rollbacks and failed deployments. This change reverts to the previous 10 minutes that didn't lead to failed deployments.