### PR TITLE
HOCS-5842: set default total_fields limit

### DIFF
--- a/localstack/elastic_mapping.json
+++ b/localstack/elastic_mapping.json
@@ -1048,7 +1048,14 @@
       }
     },
     "settings": {
-      "index.mapping.ignore_malformed": true,
+      "index": {
+        "mapping":{
+          "ignore_malformed": true,
+          "total_fields": {
+            "limit": 1500
+          }
+        }
+      },
       "analysis": {
         "analyzer": {
           "reference_analyzer": {
@@ -1074,4 +1081,3 @@
       }
     }
   }
-  


### PR DESCRIPTION
We are currently over the default `total_fields` limit of 1000. This change increases this limit to `1500` while we undergo further refactoring.