### PR TITLE
Improve healthcheck script

### DIFF
--- a/healthcheck.sh
+++ b/healthcheck.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -euo
 
-until curl 'localhost.localstack.cloud:4566/health' --silent | grep -q "\"initScripts\": \"initialized\""; do
+until curl -s 'localhost.localstack.cloud:4566/_localstack/init/ready' | jq .completed | grep -q true; do
      sleep 5
      echo "Waiting for LocalStack Initialisation scripts to have been run..."
 done


### PR DESCRIPTION
The previous implementation was checking for `initScripts` with `initialized` on the general healthcheck. This was being added prematurely before all init scripts had been run. This change improves this healthcheck to check for the completed flag on the init scripts process.