### PR TITLE
Update ElasticSearch Mapping

### DIFF
--- a/localstack/elastic_mapping.json
+++ b/localstack/elastic_mapping.json
@@ -1021,6 +1021,33 @@
                   "ignore_above": 256
                 }
               }
+            },
+            "Tier1OutcomeDateFinal": {
+              "type": "date"
+            },
+            "Mff108Date": {
+              "type": "date"
+            },
+            "EmploymentPaidDate": {
+              "type": "date"
+            },
+            "ImpactPrelimPaidDate": {
+              "type": "date"
+            },
+            "Mff125FullDate": {
+              "type": "date"
+            },
+            "ImpactPrelimSentDate": {
+              "type": "date"
+            },
+            "ImpactPrelimConsideredDate": {
+              "type": "date"
+            },
+            "LegalFeesPaidDate": {
+              "type": "date"
+            },
+            "ImpactPaidDate": {
+              "type": "date"
             }
           }
         },
@@ -1056,7 +1083,7 @@
           }
         }
       },
-      "number_of_shards": 3,
+      "number_of_shards": 1,
       "analysis": {
         "analyzer": {
           "reference_analyzer": {


### PR DESCRIPTION
Set the shard count to be 1, this was previously set to 3, but for small datasets where search performance is preferred (10–30 GiB) per index we only require 1. Our highest current index (outside the deprecated single index) is 430MiB.

This change also adds date mappings for WCS fields.