### PR TITLE
Refactor OpenSearch index and aliases

### DIFF
--- a/localstack/4-setup_index.sh
+++ b/localstack/4-setup_index.sh
@@ -20,129 +20,30 @@ until awslocal opensearch describe-domain --domain-name decs | jq ".DomainStatus
    echo "Waiting for ElasticSearch to be ready..."
 done
 
-# Multiple index mode
-curl -X PUT localhost.localstack.cloud:4566/opensearch/eu-west-2/decs/local-min --silent -H "Content-Type: application/json" -d "@${ELASTIC_MAPPING_PATH}"
-curl -X PUT localhost.localstack.cloud:4566/opensearch/eu-west-2/decs/local-tro --silent -H "Content-Type: application/json" -d "@${ELASTIC_MAPPING_PATH}"
-curl -X PUT localhost.localstack.cloud:4566/opensearch/eu-west-2/decs/local-dten --silent -H "Content-Type: application/json" -d "@${ELASTIC_MAPPING_PATH}"
-curl -X PUT localhost.localstack.cloud:4566/opensearch/eu-west-2/decs/local-mpam --silent -H "Content-Type: application/json" -d "@${ELASTIC_MAPPING_PATH}"
-curl -X PUT localhost.localstack.cloud:4566/opensearch/eu-west-2/decs/local-mts --silent -H "Content-Type: application/json" -d "@${ELASTIC_MAPPING_PATH}"
-curl -X PUT localhost.localstack.cloud:4566/opensearch/eu-west-2/decs/local-smc --silent -H "Content-Type: application/json" -d "@${ELASTIC_MAPPING_PATH}"
-curl -X PUT localhost.localstack.cloud:4566/opensearch/eu-west-2/decs/local-comp2 --silent -H "Content-Type: application/json" -d "@${ELASTIC_MAPPING_PATH}"
-curl -X PUT localhost.localstack.cloud:4566/opensearch/eu-west-2/decs/local-iedet --silent -H "Content-Type: application/json" -d "@${ELASTIC_MAPPING_PATH}"
-curl -X PUT localhost.localstack.cloud:4566/opensearch/eu-west-2/decs/local-comp --silent -H "Content-Type: application/json" -d "@${ELASTIC_MAPPING_PATH}"
-curl -X PUT localhost.localstack.cloud:4566/opensearch/eu-west-2/decs/local-foi --silent -H "Content-Type: application/json" -d "@${ELASTIC_MAPPING_PATH}"
-curl -X PUT localhost.localstack.cloud:4566/opensearch/eu-west-2/decs/local-bf --silent -H "Content-Type: application/json" -d "@${ELASTIC_MAPPING_PATH}"
-curl -X PUT localhost.localstack.cloud:4566/opensearch/eu-west-2/decs/local-bf2 --silent -H "Content-Type: application/json" -d "@${ELASTIC_MAPPING_PATH}"
-curl -X PUT localhost.localstack.cloud:4566/opensearch/eu-west-2/decs/local-to --silent -H "Content-Type: application/json" -d "@${ELASTIC_MAPPING_PATH}"
-curl -X PUT localhost.localstack.cloud:4566/opensearch/eu-west-2/decs/local-pogr --silent -H "Content-Type: application/json" -d "@${ELASTIC_MAPPING_PATH}"
-curl -X PUT localhost.localstack.cloud:4566/opensearch/eu-west-2/decs/local-pogr2 --silent -H "Content-Type: application/json" -d "@${ELASTIC_MAPPING_PATH}"
-curl -X PUT localhost.localstack.cloud:4566/opensearch/eu-west-2/decs/local-wcs --silent -H "Content-Type: application/json" -d "@${ELASTIC_MAPPING_PATH}"
+# Create the indexes and aliases
+types=("min" "tro" "dten" "mpam" "mts" "smc" "comp2" "iedet" "comp" "foi" "bf" "bf2" "to" "pogr" "pogr2" "wcs")
+for type in "${types[@]}"
+do
+    echo
+    echo "Creating index for ${type}"
+    echo
+    curl -X PUT localhost.localstack.cloud:4566/opensearch/eu-west-2/decs/local-"${type}" --silent -H "Content-Type: application/json" -d "@${ELASTIC_MAPPING_PATH}"
 
-curl -X POST localhost.localstack.cloud:4566/opensearch/eu-west-2/decs/_aliases --silent -H "Content-Type: application/json" -d '{
-"actions":[
-   {
-      "add":{
-         "index":"local-*",
-         "alias":"local-read"
-      }
-   },
-   {
-      "add":{
-         "index":"local-min",
-         "alias":"local-min-read"
-      }
-   },
-   {
-      "add":{
-         "index":"local-tro",
-         "alias":"local-tro-read"
-      }
-   },
-   {
-      "add":{
-         "index":"local-dten",
-         "alias":"local-dten-read"
-      }
-   },
-   {
-      "add":{
-         "index":"local-mpam",
-         "alias":"local-mpam-read"
-      }
-   },
-   {
-      "add":{
-         "index":"local-mts",
-         "alias":"local-mts-read"
-      }
-   },
-   {
-      "add":{
-         "index":"local-smc",
-         "alias":"local-smc-read"
-      }
-   },
-   {
-      "add":{
-         "index":"local-comp2",
-         "alias":"local-comp2-read"
-      }
-   },
-   {
-      "add":{
-         "index":"local-iedet",
-         "alias":"local-iedet-read"
-      }
-   },
-   {
-      "add":{
-         "index":"local-comp",
-         "alias":"local-comp-read"
-      }
-   },
-   {
-      "add":{
-         "index":"local-foi",
-         "alias":"local-foi-read"
-      }
-   },
-   {
-      "add":{
-         "index":"local-bf",
-         "alias":"local-bf-read"
-      }
-   },
-   {
-      "add":{
-         "index":"local-bf2",
-         "alias":"local-bf2-read"
-      }
-   },
-   {
-      "add":{
-         "index":"local-to",
-         "alias":"local-to-read"
-      }
-   },
-   {
-      "add":{
-         "index":"local-pogr",
-         "alias":"local-pogr-read"
-      }
-   },
-   {
-      "add":{
-         "index":"local-pogr2",
-         "alias":"local-pogr2-read"
-      }
-   },
-   {
-      "add":{
-         "index":"local-wcs",
-         "alias":"local-wcs-read"
-      }
-   }
+    echo
+    echo "Creating alias for ${type}"
+    echo
+    curl -X POST localhost.localstack.cloud:4566/opensearch/eu-west-2/decs/_aliases --silent -H "Content-Type: application/json" -d "{\"actions\":
+    [
+      {\"add\": {\"index\":\"local-${type}\", \"alias\":\"local-${type}-read\"}},
+      {\"add\": {\"index\":\"local-${type}\", \"alias\":\"local-${type}-write\"}}
+    ]}"
+done
+
+# Create the alias for all indexes
+curl -X POST localhost.localstack.cloud:4566/opensearch/eu-west-2/decs/_aliases --silent -H "Content-Type: application/json" -d '{"actions":
+    [
+      {"add":{"index":"local-*","alias":"local-read"}}
 ]}'
 
-# Kept while SINGULAR mode is supported
+# Create the index for singular
 curl -X PUT localhost.localstack.cloud:4566/opensearch/eu-west-2/decs/local-case --silent -H "Content-Type: application/json" -d "@${ELASTIC_MAPPING_PATH}"


### PR DESCRIPTION
This change adds in a missing write alias for each of the multiple indexes. Alongside this, the creation of the index and aliases has been improved for readability and extensibility going forward to use a loop.