### PR TITLE
Update version in docker-compose.kafka.yml file

### DIFF
--- a/docker-compose.kafka.yml
+++ b/docker-compose.kafka.yml
@@ -1,5 +1,5 @@
 ---
-version: '1'
+version: '3'
 services:
   zookeeper:
     image: confluentinc/cp-zookeeper:7.3.1


### PR DESCRIPTION
version: '1' breaks the docker compose in the integration tests of hocs-txa-document-extractor run during that repo's GitHub actions.

Need to increment the version to a currently-supported version.
