### PR TITLE
Feature/hocs 6820 upgrade keycloak

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -254,7 +254,8 @@ services:
       - keycloak
 
   keycloak:
-    image: quay.io/keycloak/keycloak:15.1.1
+    image: quay.io/keycloak/keycloak:22.0.4
+    command: ["start-dev"]
     restart: on-failure
     ports:
       - "9990:9990"
@@ -262,7 +263,7 @@ services:
     networks:
       - hocs-network
     environment:
-      JAVA_OPTS: "-Xms32m -Xmx128m"
+      #"JAVA_OPTS: "-Xms128m -Xmx256m"
       KEYCLOAK_USER: root
       KEYCLOAK_PASSWORD: dev
       KEYCLOAK_IMPORT: /tmp/local-realm.json

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -264,15 +264,15 @@ services:
       - hocs-network
     environment:
       JAVA_OPTS: "-Xms128m -Xmx256m"
-      KEYCLOAK_USER: root
-      KEYCLOAK_PASSWORD: dev
+      KEYCLOAK_ADMIN: root
+      KEYCLOAK_ADMIN_PASSWORD: dev
       KEYCLOAK_IMPORT: /tmp/local-realm.json
-      DB_VENDOR: postgres
-      DB_ADDR: postgres
-      DB_PORT: 5432
-      DB_DATABASE: postgres
-      DB_USER: root
-      DB_PASSWORD: dev
+      KC_DB: postgres
+      KC_DB_URL_HOST: postgres
+      KC_DB_URL_PORT: 5432
+      KC_DB_URL_DATABASE: postgres
+      KC_DB_USERNAME: root
+      KC_DB_PASSWORD: dev
     healthcheck:
       test: "curl -f http://localhost:8080/auth/ || exit 1"
       timeout: 5s

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -254,8 +254,8 @@ services:
       - keycloak
 
   keycloak:
-    image: quay.io/keycloak/keycloak:22.0.4
-    command: ["start-dev"]
+    image: quay.io/keycloak/keycloak:22.0.5
+    command: ["start-dev  --import-realm"]
     restart: on-failure
     ports:
       - "9990:9990"
@@ -266,7 +266,6 @@ services:
       JAVA_OPTS: "-Xms128m -Xmx256m"
       KEYCLOAK_ADMIN: root
       KEYCLOAK_ADMIN_PASSWORD: dev
-      KEYCLOAK_IMPORT: /tmp/local-realm.json
       KC_DB: postgres
       KC_DB_URL_HOST: postgres
       KC_DB_URL_PORT: 5432
@@ -274,11 +273,11 @@ services:
       KC_DB_USERNAME: root
       KC_DB_PASSWORD: dev
     healthcheck:
-      test: "curl -f http://localhost:8080/auth/ || exit 1"
+      test: "curl -f http://localhost:8080/ || exit 1"
       timeout: 5s
       retries: 40
     volumes:
-      - ${PWD}/ci/keycloak/local-realm.json:/tmp/local-realm.json
+      - ${PWD}/ci/keycloak/local-realm.json:/opt/keycloak/data/import/local-realm.json
     depends_on:
       - postgres
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -263,7 +263,7 @@ services:
     networks:
       - hocs-network
     environment:
-      #"JAVA_OPTS: "-Xms128m -Xmx256m"
+      JAVA_OPTS: "-Xms128m -Xmx256m"
       KEYCLOAK_USER: root
       KEYCLOAK_PASSWORD: dev
       KEYCLOAK_IMPORT: /tmp/local-realm.json


### PR DESCRIPTION
HOCS:6820 - This PR would include changes to upgrade keycloak
version to 22.0.5 and this is inline with HOCS-6824 to upgrade to latest version
As part of this - few things have changes including start up command to include start-dev
and import realm as a parameter. Also authentication url changed to include auth in 
the resource name. Local realm is included as part of volumes and I have tested this 
in local to see if the realm are loaded. Also tested MUI by creating a new user 
in local keycloak and validated this in UI.